### PR TITLE
Misc workflow cleanups and URL change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,18 +96,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure git
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-      - name: Mark full release
-        uses: actions/github-script@v6
-        env:
-          NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
-        with:
-          script: await require('.ci/mark-release.js')({require, context, core, github});
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -119,3 +107,10 @@ jobs:
         env:
           NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
         run: .ci/push-containers.sh
+
+      - name: Mark full release
+        uses: actions/github-script@v6
+        env:
+          NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
+        with:
+          script: await require('.ci/mark-release.js')({require, context, core, github});

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ becomes available in an official release. Or if you like living on the edge.
 
 Pick the release that you want to use. Each release has usage instructions
 attached to it:
-<https://github.com/numtide/nix-unstable-installer/releases/latest>
+<https://github.com/nix-community/nix-unstable-installer/releases/latest>
 
 ## How it works
 

--- a/update.rb
+++ b/update.rb
@@ -132,7 +132,7 @@ def get_eval(eval_id, skip_existing_tag = false)
   end
 
   server_url = ENV.fetch('GITHUB_SERVER_URL', 'https://github.com')
-  repository = ENV.fetch('GITHUB_REPOSITORY', 'numtide/nix-unstable-installer')
+  repository = ENV.fetch('GITHUB_REPOSITORY', 'nix-community/nix-unstable-installer')
 
   # Rewrite the installer
   rewrite("dist/install") do |body|

--- a/update.rb
+++ b/update.rb
@@ -204,9 +204,10 @@ def main(eval_id)
 
     # Output for CI automation
     if ENV.fetch("GITHUB_ACTIONS", "false") == "true"
-      puts "::set-output name=nix_release::#{release_name}"
-
-      puts "::set-output name=updated::#{updated}"
+      File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |file|
+        file.puts "nix_release=#{release_name}"
+        file.puts "updated=#{updated}"
+      end
     end
   else
     get_eval(eval_id)


### PR DESCRIPTION
Changes in this PR:
* Per the deprecation of the `set-output` workflow command (see [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)), changes the update script to use the new `GITHUB_OUTPUT` environment file
* Waits until after the container image is uploaded to GHCR to mark the full release
* Defaults to the new `nix-community/nix-unstable-installer` URL