### PR TITLE
ci: propagate GITHUB_TOKEN into the container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,11 @@ jobs:
         if: runner.os == 'Linux'
         env:
           NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          docker run --rm "nix:${NIX_RELEASE#nix-}" \
-            nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nix-info -- -m
+          docker run --rm -e GITHUB_TOKEN "nix:${NIX_RELEASE#nix-}" \
+            sh -c 'echo "access-tokens = github.com=$GITHUB_TOKEN" >> /etc/nix/nix.conf && \
+                   nix --extra-experimental-features "nix-command flakes" run nixpkgs#nix-info -- -m'
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       nix_release: ${{ steps.update.outputs.nix_release }}
       updated: ${{ steps.update.outputs.updated }}
     steps:
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
@@ -57,11 +57,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v19
         with:
           install_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Run nix-info


### PR DESCRIPTION
This can avoid rate-limiting errors in the `nix-info` test in container (GITHUB_TOKEN was already used for the initial non-container `nix-info` test)

I'll merge in a few hours and rerun to fix the failed update yesterday (unless someone has comments)